### PR TITLE
Allow fee transfer from user to fee collector

### DIFF
--- a/contracts/GelatoRelayContext.sol
+++ b/contracts/GelatoRelayContext.sol
@@ -67,6 +67,44 @@ abstract contract GelatoRelayContext is GelatoRelayBase {
         _getFeeToken().transfer(_getFeeCollector(), fee);
     }
 
+    // DANGER! Only use with onlyGelatoRelay `_isGelatoRelay` before transferring
+    function _transferFromRelayFee(address _from) internal {
+        _getFeeToken().transferFrom(_from, _getFeeCollector(), _getFee());
+    }
+
+    // DANGER! Only use with onlyGelatoRelay `_isGelatoRelay` before transferring
+    function _transferFromRelayFeeCapped(address _from, uint256 _maxFee)
+        internal
+    {
+        uint256 fee = _getFee();
+        require(
+            fee <= _maxFee,
+            "GelatoRelayContext._transferFromRelayFeeCapped: maxFee"
+        );
+        _getFeeToken().transferFrom(_from, _getFeeCollector(), fee);
+    }
+
+    // DANGER! Only use with onlyGelatoRelay `_isGelatoRelay` before transferring
+    function _permitTransferFromRelayFeeCapped(
+        address _from,
+        uint256 _maxFee,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) internal {
+        uint256 fee = _getFee();
+        require(
+            fee <= _maxFee,
+            "GelatoRelayContext._permitTransferFromRelayFeeCapped: maxFee"
+        );
+
+        address token = _getFeeToken();
+        token.permit(_from, address(this), _maxFee, _deadline, _v, _r, _s);
+
+        token.transferFrom(_from, _getFeeCollector(), fee);
+    }
+
     function _getMsgData() internal view returns (bytes calldata) {
         return
             _isGelatoRelay(msg.sender)

--- a/contracts/GelatoRelayContext.sol
+++ b/contracts/GelatoRelayContext.sol
@@ -85,7 +85,7 @@ abstract contract GelatoRelayContext is GelatoRelayBase {
     }
 
     // DANGER! Only use with onlyGelatoRelay `_isGelatoRelay` before transferring
-    function _permitTransferFromRelayFeeCapped(
+    function _transferFromRelayFeeCappedWithPermit(
         address _from,
         uint256 _maxFee,
         uint256 _deadline,
@@ -96,7 +96,7 @@ abstract contract GelatoRelayContext is GelatoRelayBase {
         uint256 fee = _getFee();
         require(
             fee <= _maxFee,
-            "GelatoRelayContext._permitTransferFromRelayFeeCapped: maxFee"
+            "GelatoRelayContext._transferFromRelayFeeCappedWithPermit: maxFee"
         );
 
         address token = _getFeeToken();

--- a/contracts/GelatoRelayContextERC2771.sol
+++ b/contracts/GelatoRelayContextERC2771.sol
@@ -88,6 +88,47 @@ abstract contract GelatoRelayContextERC2771 is GelatoRelayERC2771Base {
         _getFeeToken().transfer(_getFeeCollector(), fee);
     }
 
+    // DANGER! Only use with onlyGelatoRelayERC2771, onlyGelatoRelayConcurrentERC2771,
+    // `_isGelatoRelayERC2771` or `_isGelatoRelayConcurrentERC2771` checks
+    function _transferFromRelayFee(address _from) internal {
+        _getFeeToken().transferFrom(_from, _getFeeCollector(), _getFee());
+    }
+
+    // DANGER! Only use with onlyGelatoRelayERC2771, onlyGelatoRelayConcurrentERC2771,
+    // `_isGelatoRelayERC2771` or `_isGelatoRelayConcurrentERC2771` checks
+    function _transferFromRelayFeeCapped(address _from, uint256 _maxFee)
+        internal
+    {
+        uint256 fee = _getFee();
+        require(
+            fee <= _maxFee,
+            "GelatoRelayContextERC2771._transferFromRelayFeeCapped: maxFee"
+        );
+        _getFeeToken().transferFrom(_from, _getFeeCollector(), fee);
+    }
+
+    // DANGER! Only use with onlyGelatoRelayERC2771, onlyGelatoRelayConcurrentERC2771,
+    // `_isGelatoRelayERC2771` or `_isGelatoRelayConcurrentERC2771` checks
+    function _permitTransferFromRelayFeeCapped(
+        address _from,
+        uint256 _maxFee,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) internal {
+        uint256 fee = _getFee();
+        require(
+            fee <= _maxFee,
+            "GelatoRelayContextERC2771._permitTransferFromRelayFeeCapped: maxFee"
+        );
+
+        address token = _getFeeToken();
+        token.permit(_from, address(this), _maxFee, _deadline, _v, _r, _s);
+
+        token.transferFrom(_from, _getFeeCollector(), fee);
+    }
+
     function _getMsgData() internal view virtual returns (bytes calldata) {
         return
             _isGelatoRelayERC2771(msg.sender)

--- a/contracts/GelatoRelayContextERC2771.sol
+++ b/contracts/GelatoRelayContextERC2771.sol
@@ -109,7 +109,7 @@ abstract contract GelatoRelayContextERC2771 is GelatoRelayERC2771Base {
 
     // DANGER! Only use with onlyGelatoRelayERC2771, onlyGelatoRelayConcurrentERC2771,
     // `_isGelatoRelayERC2771` or `_isGelatoRelayConcurrentERC2771` checks
-    function _permitTransferFromRelayFeeCapped(
+    function _transferFromRelayFeeCappedWithPermit(
         address _from,
         uint256 _maxFee,
         uint256 _deadline,
@@ -120,7 +120,7 @@ abstract contract GelatoRelayContextERC2771 is GelatoRelayERC2771Base {
         uint256 fee = _getFee();
         require(
             fee <= _maxFee,
-            "GelatoRelayContextERC2771._permitTransferFromRelayFeeCapped: maxFee"
+            "GelatoRelayContextERC2771._transferFromRelayFeeCappedWithPermit: maxFee"
         );
 
         address token = _getFeeToken();

--- a/contracts/lib/TokenUtils.sol
+++ b/contracts/lib/TokenUtils.sol
@@ -2,18 +2,43 @@
 pragma solidity ^0.8.1;
 
 import {NATIVE_TOKEN} from "../constants/Tokens.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    IERC20Permit
+} from "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 import {
     SafeERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 library TokenUtils {
     using SafeERC20 for IERC20;
+    using SafeERC20 for IERC20Permit;
 
     modifier onlyERC20(address _token) {
         require(_token != NATIVE_TOKEN, "TokenUtils.onlyERC20");
         _;
+    }
+
+    function permit(
+        address _token,
+        address _owner,
+        address _spender,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) internal onlyERC20(_token) {
+        IERC20Permit(_token).safePermit(
+            _owner,
+            _spender,
+            _value,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
     }
 
     function transfer(


### PR DESCRIPTION
# Allow direct fee transfer from user to fee collector

## Motivation

We would like to be able to transfer fees directly from a user account to the fee collector.
The user must have either previously approved the contract spending or must sign a permit signature approving spending.

## Solution

To support this we modify existing context contracts:
- `GelatoRelayContext.sol`
- `GelatoRelayContextERC2771.sol`

We introduce the following methods:
- `_transferFromRelayFee`
- `_transferFromRelayFeeCapped`
- `_transferFromRelayFeeCappedWithPermit`

## Security Considerations

### Roles and permissions

- [ ] It's Permissionless!
- [x] Roles and permissions listed below:

For `GelatoRelayContext.sol`, should only be used with the following before transferring:
- `onlyGelatoRelay`
- `_isGelatoRelay`

For `GelatoRelayContextERC2771.sol`, should only be used with the following before transferring:
- `onlyGelatoRelayERC2771`
- `onlyGelatoRelayConcurrentERC2771`
- `_isGelatoRelayERC2771`
- `_isGelatoRelayConcurrentERC2771`

### External Contracts

- [x] No external contracts.
- [ ] External contracts listed below:

### Deployment

Is this a new deployment or an upgrade to a deployed upgradable contract?

- [x] New deployment.
- [ ] Upgrade to a deployed upgradable contract:

### FUNDS AND PRIVILEGES

Does the contract hold any funds or privileges?

- [ ] No funds, allowance, or privileges.
- [x] Some:

The contract is user-deployed so it may contain funds (e.g., for relay fee payment).

## Checklist

- [x] I have performed a self-review of my code
- [x] If it is a new feature, I have added thorough tests.
- [ ] I have run your code through basic code analysis tools (Slither)
- [x] Solidity does not emit ANY compiler warnings.
- [x] The code is well-documented
- [x] The code has been deployed and tested on a forking network