### PR TITLE
Unify trusted forwarder checks

### DIFF
--- a/contracts/__mocks__/MockGelatoRelayContextERC2771.sol
+++ b/contracts/__mocks__/MockGelatoRelayContextERC2771.sol
@@ -32,12 +32,4 @@ contract MockGelatoRelayContextERC2771 is GelatoRelayContextERC2771 {
 
     // solhint-disable-next-line no-empty-blocks
     function testOnlyGelatoRelayERC2771() external onlyGelatoRelayERC2771 {}
-
-    function testOnlyGelatoRelayConcurrentERC2771()
-        external
-        onlyGelatoRelayConcurrentERC2771
-    // solhint-disable-next-line no-empty-blocks
-    {
-
-    }
 }

--- a/contracts/__mocks__/MockGelatoRelayFeeCollectorERC2771.sol
+++ b/contracts/__mocks__/MockGelatoRelayFeeCollectorERC2771.sol
@@ -19,12 +19,4 @@ contract MockGelatoRelayFeeCollectorERC2771 is GelatoRelayFeeCollectorERC2771 {
 
     // solhint-disable-next-line no-empty-blocks
     function testOnlyGelatoRelayERC2771() external onlyGelatoRelayERC2771 {}
-
-    function testOnlyGelatoRelayConcurrentERC2771()
-        external
-        onlyGelatoRelayConcurrentERC2771
-    // solhint-disable-next-line no-empty-blocks
-    {
-
-    }
 }

--- a/contracts/base/GelatoRelayERC2771Base.sol
+++ b/contracts/base/GelatoRelayERC2771Base.sol
@@ -14,14 +14,6 @@ abstract contract GelatoRelayERC2771Base {
         _;
     }
 
-    modifier onlyGelatoRelayConcurrentERC2771() {
-        require(
-            _isGelatoRelayConcurrentERC2771(msg.sender),
-            "onlyGelatoRelayConcurrentERC2771"
-        );
-        _;
-    }
-
     function _isGelatoRelayERC2771(address _forwarder)
         internal
         view
@@ -29,20 +21,10 @@ abstract contract GelatoRelayERC2771Base {
     {
         // Use another address on zkSync
         if (block.chainid == 324 || block.chainid == 280) {
-            return _forwarder == GELATO_RELAY_ERC2771_ZKSYNC;
+            return (_forwarder == GELATO_RELAY_ERC2771_ZKSYNC ||
+                _forwarder == GELATO_RELAY_CONCURRENT_ERC2771_ZKSYNC);
         }
-        return _forwarder == GELATO_RELAY_ERC2771;
-    }
-
-    function _isGelatoRelayConcurrentERC2771(address _forwarder)
-        internal
-        view
-        returns (bool)
-    {
-        // Use another address on zkSync
-        if (block.chainid == 324 || block.chainid == 280) {
-            return _forwarder == GELATO_RELAY_CONCURRENT_ERC2771_ZKSYNC;
-        }
-        return _forwarder == GELATO_RELAY_CONCURRENT_ERC2771;
+        return (_forwarder == GELATO_RELAY_ERC2771 ||
+            _forwarder == GELATO_RELAY_CONCURRENT_ERC2771);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gelatonetwork/relay-context",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Solidity and test helpers for implementing GelatoRelayContext",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/test/MockRelayContextERC2771.test.ts
+++ b/test/MockRelayContextERC2771.test.ts
@@ -262,10 +262,4 @@ describe("Test MockGelatoRelayContextERC2771 Smart Contract", function () {
       mockRelayContextERC2771.testOnlyGelatoRelayERC2771()
     ).to.be.revertedWith("onlyGelatoRelayERC2771");
   });
-
-  it("#7: testOnlyGelatoRelayConcurrentERC2771 reverts if not GelatoRelay", async () => {
-    await expect(
-      mockRelayContextERC2771.testOnlyGelatoRelayConcurrentERC2771()
-    ).to.be.revertedWith("onlyGelatoRelayConcurrentERC2771");
-  });
 });

--- a/test/MockRelayFeeCollectorERC2771.test.ts
+++ b/test/MockRelayFeeCollectorERC2771.test.ts
@@ -135,10 +135,4 @@ describe("Test MockGelatoRelayFeeCollectorERC2771 Smart Contract", function () {
       mockRelayFeeCollectorERC2771.testOnlyGelatoRelayERC2771()
     ).to.be.revertedWith("onlyGelatoRelayERC2771");
   });
-
-  it("#3: testOnlyGelatoRelayConcurrentERC2771 reverts if not GelatoRelay", async () => {
-    await expect(
-      mockRelayFeeCollectorERC2771.testOnlyGelatoRelayConcurrentERC2771()
-    ).to.be.revertedWith("onlyGelatoRelayConcurrentERC2771");
-  });
 });


### PR DESCRIPTION
We unify:
- `onlyGelatoRelayERC2771` and `onlyGelatoRelayConcurrentERC2771`.
- `_isGelatoRelayERC2771` and `_isGelatoRelayConcurrentERC2771`.

This is desirable since:
- Users don't need to differentiate between sequential/concurrent calls on-chain.
- Only frontend changes are required to switch between the two.
- `_msgSender` and `_msgData` work without requiring concurrent variants.