### PR TITLE
fix: safePermit deprecated

### DIFF
--- a/contracts/lib/TokenUtils.sol
+++ b/contracts/lib/TokenUtils.sol
@@ -30,7 +30,7 @@ library TokenUtils {
         bytes32 _r,
         bytes32 _s
     ) internal onlyERC20(_token) {
-        IERC20Permit(_token).safePermit(
+        IERC20Permit(_token).permit(
             _owner,
             _spender,
             _value,


### PR DESCRIPTION
The safepermit was deprecated in favor of the permit on [this](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/095c8e120c0cc0d9003db358708740bcbc4276a1) contract update.

Due to this issue is no longer possible to use the GelatoRelayContext on new contracts.
![Screenshot 2024-02-28 at 01 14 26](https://github.com/gelatodigital/relay-context-contracts/assets/10758611/e9fed496-afcc-43fd-8952-0fe46b8d1227)
